### PR TITLE
#38: Make Content-Format 287 a MUST for servers

### DIFF
--- a/draft-ietf-ace-coap-est-oscore.md
+++ b/draft-ietf-ace-coap-est-oscore.md
@@ -293,8 +293,7 @@ As a reminder, Content-Format negotiation happens through CoAP's Accept option p
 |       | application/csrattrs                          | res |  285  |
 {: #table_mediatype_asn1 cols="l l" title="EST functions and the associated ASN.1 CoAP Content-Format identifiers"}
 
-Content-Format 281 MUST be supported by EST-oscore servers.
-Servers MAY also support Content-Format 287.
+Content-Format 281 and Content-Format 287 MUST be supported by EST-oscore servers.
 It is up to the client to support only Content-Format 281, 287 or both.
 As indicated in {{Section 4.3 of RFC9148}}, the client will use a CoAP Accept Option in the request to express the preferred response Content-Format.
 If an Accept Option is not included in the request, the client is not expressing any preference and the server SHOULD choose format 281.


### PR DESCRIPTION
This is a simple PR which changes the normative requirements on Content-Format support, as per #38.